### PR TITLE
Fix an issue with jbuilder.1.0+beta19

### DIFF
--- a/jbuild
+++ b/jbuild
@@ -3,5 +3,4 @@
 (library
  ((name       ocaml_version) 
   (public_name ocaml-version)
-  (libraries  (bytes))
  ))


### PR DESCRIPTION
Related to https://github.com/ocaml/opam-repository/pull/11605

The ```bytes``` dependency should be avoided since jbuilder/dune already depends on the OCaml >= 4.02.0.